### PR TITLE
Wolox Dialog Fragment

### DIFF
--- a/WoloxAndroidBootstrap/app/src/main/java/ar/com/wolox/android/fragment/WoloxDialogFragment.java
+++ b/WoloxAndroidBootstrap/app/src/main/java/ar/com/wolox/android/fragment/WoloxDialogFragment.java
@@ -1,18 +1,15 @@
 package ar.com.wolox.android.fragment;
 
-import android.content.Context;
 import android.os.Bundle;
-import android.support.v4.app.Fragment;
+import android.support.v4.app.DialogFragment;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.view.inputmethod.InputMethodManager;
-import android.widget.EditText;
 import android.widget.Toast;
 
 import ar.com.wolox.android.presenter.BasePresenter;
 
-public abstract class WoloxFragment<T extends BasePresenter> extends DialogFragment {
+public abstract class WoloxDialogFragment<T extends BasePresenter> extends DialogFragment {
 
     protected T presenter;
 


### PR DESCRIPTION
### Summary

Add a `WoloxDialogFragment` to be used when custom dialogs want to be used. The logic is pretty much the same as the `DialogFragment`, nothing really new, but the importance of it is to be used when someone needs to make a custom dialog and doesn't know how.
