### PR TITLE
Added Shared Element Transitions

### DIFF
--- a/WoloxAndroidBootstrap/app/src/main/java/ar/com/wolox/android/utils/NavigationUtils.java
+++ b/WoloxAndroidBootstrap/app/src/main/java/ar/com/wolox/android/utils/NavigationUtils.java
@@ -1,0 +1,113 @@
+package ar.com.wolox.android.utils;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
+import android.support.v4.app.ActivityCompat;
+import android.support.v4.app.ActivityOptionsCompat;
+import android.support.v4.util.Pair;
+import android.view.View;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+
+public class NavigationUtils {
+
+    public static void jumpTo(Context context, Class clazz, IntentObject... intentObjects) {
+        Intent intent = new Intent(context, clazz);
+        for (IntentObject intentObject : intentObjects) {
+            intent.putExtra(intentObject.reference, intentObject.object);
+        }
+        context.startActivity(intent);
+    }
+
+    public static void jumpToClearingTask(Context context, Class clazz,
+                                          IntentObject... intentObjects) {
+        Intent intent = new Intent(context, clazz);
+        for (IntentObject intentObject : intentObjects) {
+            intent.putExtra(intentObject.reference, intentObject.object);
+        }
+        intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
+        context.startActivity(intent);
+    }
+
+    public static void jumpToWithAnimation(Activity activity,
+                                           Class clazz,
+                                           ActivityOptionsCompat transitionActivityOptions,
+                                           IntentObject... intentObjects) {
+        Intent intent = new Intent(activity, clazz);
+        for (IntentObject intentObject : intentObjects) {
+            intent.putExtra(intentObject.reference, intentObject.object);
+        }
+        ActivityCompat.startActivity(activity, intent, transitionActivityOptions.toBundle());
+    }
+
+    public static ActivityOptionsCompat buildActivityOptions(
+            Activity activity, Pair<View, String>... pairs) {
+        return ActivityOptionsCompat
+                .makeSceneTransitionAnimation(activity, pairs);
+    }
+
+    public static class Builder {
+
+        private Activity activity;
+        private Class clazz;
+        private ArrayList<Pair<View, String>> sharedElements;
+        private ArrayList<IntentObject> intentObjects;
+
+        public Builder(Activity activity) {
+            this.activity = activity;
+            sharedElements = new ArrayList<>();
+            intentObjects = new ArrayList<>();
+        }
+
+        public Builder setClass(Class clazz) {
+            this.clazz = clazz;
+            return this;
+        }
+
+        public Builder addSharedElement(View sharedView, String sharedString) {
+            sharedElements.add(new Pair<View, String>(sharedView, sharedString));
+            return this;
+        }
+
+        public Builder addIntentObjects(IntentObject... intentObjects) {
+            for (IntentObject intentObject : intentObjects) addIntentObject(intentObject);
+            return this;
+        }
+
+        public Builder addIntentObject(IntentObject intentObject) {
+            this.intentObjects.add(intentObject);
+            return this;
+        }
+
+        public Builder addExtra(String reference, Serializable object) {
+            addIntentObject(new IntentObject(reference, object));
+            return this;
+        }
+
+        public void jump() {
+            if (sharedElements.isEmpty()) {
+                jumpTo(activity, clazz,
+                        intentObjects.toArray(new IntentObject[intentObjects.size()]));
+            } else {
+                jumpToWithAnimation(activity, clazz, buildActivityOptions(activity,
+                        sharedElements.toArray(new Pair[sharedElements.size()])),
+                        intentObjects.toArray(new IntentObject[intentObjects.size()]));
+            }
+
+        }
+    }
+
+    public static class IntentObject {
+        private String reference;
+        private Serializable object;
+
+        public IntentObject(String reference, Serializable object) {
+            this.reference = reference;
+            this.object = object;
+        }
+    }
+}

--- a/WoloxAndroidBootstrap/app/src/main/res/values-v21/styles.xml
+++ b/WoloxAndroidBootstrap/app/src/main/res/values-v21/styles.xml
@@ -1,0 +1,15 @@
+<resources>
+
+    <!-- Base application theme. -->
+    <style name="AppTheme" parent="Theme.AppCompat.Light.NoActionBar">
+
+        <item name="android:windowContentTransitions">true</item>
+
+        <item name="android:windowAllowEnterTransitionOverlap">false</item>
+        <item name="android:windowAllowReturnTransitionOverlap">false</item>
+        <item name="android:windowSharedElementEnterTransition">@android:transition/move</item>
+        <item name="android:windowSharedElementExitTransition">@android:transition/move</item>
+
+    </style>
+
+</resources>


### PR DESCRIPTION
## Summary

Added the `NavigationUtils` class with the option to open a new activity with an animation.
The animation allows any element that's shared between the two activities to move from the position it's at in the first one to the position it will be in in the second one.

For more specifics on how to use this and make the animations, please see the [wiki page](https://github.com/Wolox/WoloxAndroidBootstrap/wiki/Shared-Element-Transition) on this.
## Example video

_From MatchMaker_
![circles animation](https://cloud.githubusercontent.com/assets/6062888/12004310/e041a0b4-ab2d-11e5-937b-2d2a9038f6bd.gif)
