### PR TITLE
Modified min API level supported to 19

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -18,7 +18,7 @@ android {
 
     defaultConfig {
         applicationId "ar.com.wolox.android.example"
-        minSdkVersion 16
+        minSdkVersion 19
         targetSdkVersion 25
         versionCode 1
         versionName "1.0.0"


### PR DESCRIPTION
# Modified min API level supported to 19

From now on, we will be supporting a minimum API level of 19.
This change has been made due to the fact that the amount of active Android devices running APIs 19+ worldwide has achieved over 90%.