### PR TITLE
Bump wolmo version to v1.3.0, upgrade to gradle plugin 3.0.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -13,13 +13,13 @@ idea {
 }
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.3'
+    compileSdkVersion 26
+    buildToolsVersion '26.0.2'
 
     defaultConfig {
         applicationId "ar.com.wolox.android.example"
         minSdkVersion 19
-        targetSdkVersion 25
+        targetSdkVersion 26
         versionCode 1
         versionName "1.0.0"
 
@@ -54,6 +54,9 @@ android {
         }
     }
 
+    // Change the "default" to whatever fits. At least one 'dimension' is required by gradle.
+    flavorDimensions "default"
+
     productFlavors {
         stage {
             applicationId defaultConfig.applicationId + ".stage"
@@ -73,18 +76,23 @@ android {
     lintOptions {
         abortOnError false
     }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
 }
 
 buildscript {
-    ext.support_library_version = '25.3.1'
+    ext.support_library_version = '26.1.0'
     ext.butterknife_version = '8.6.0'
     ext.chuck_version = '1.0.4'
     ext.leak_canary_version = '1.5.1'
-    ext.wolmo_version = 'v1.1.0'
+    ext.wolmo_version = 'v1.3.0'
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
+    compile fileTree(include: ['*.jar'], dir: 'libs')
 
     // Wolmo
     compile "com.github.Wolox:wolmo-core-android:$wolmo_version"

--- a/build.gradle
+++ b/build.gradle
@@ -2,10 +2,11 @@
 buildscript {
     repositories {
         mavenCentral()
+        google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.2'
+        classpath 'com.android.tools.build:gradle:3.0.0'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }
@@ -15,5 +16,6 @@ allprojects {
     repositories {
         mavenCentral()
         maven { url "https://jitpack.io" }
+        google()
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Jun 05 16:41:00 ART 2017
+#Mon Oct 30 17:27:18 ART 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip


### PR DESCRIPTION
## Summary

Updated `Wolmo` version to **v1.3.0** along with the `gradle` plugin to **3.0.0**.